### PR TITLE
Make version information more compact.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,12 @@
 define build
 	@echo "Building git-credential-netlify for $(os)/$(arch)"
 	@mkdir -p builds/$(os)-${TAG}
-	@GO111MODULE=on CGO_ENABLED=0 GOOS=$(os) GOARCH=$(arch) go build -ldflags "-X github.com/netlify/netlify-credential-helper/credentials.Version=${TAG} -X github.com/netlify/netlify-credential-helper/credentials.SHA=`git rev-parse HEAD`" -o builds/$(os)-${TAG}/git-credential-netlify$(1) cmd/netlify-credential-helper/main.go
+	@GO111MODULE=on CGO_ENABLED=0 GOOS=$(os) GOARCH=$(arch) go build \
+		-ldflags "-X github.com/netlify/netlify-credential-helper/credentials.tag=${TAG} \
+		-X github.com/netlify/netlify-credential-helper/credentials.sha=`git rev-parse HEAD` \
+		-X github.com/netlify/netlify-credential-helper/credentials.distro=$(os) \
+		-X github.com/netlify/netlify-credential-helper/credentials.arch=$(arch)" \
+		-o builds/$(os)-${TAG}/git-credential-netlify$(1) cmd/netlify-credential-helper/main.go
 	@echo "Built: builds/$(os)-${TAG}/git-credential-netlify"
 endef
 

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 
 	"github.com/sirupsen/logrus"
 )
@@ -27,8 +28,10 @@ const (
 )
 
 var (
-	Version = "static-binary-version"
-	SHA     = "static-binary-sha"
+	tag    = "static-binary-tag"
+	sha    = "static-binary-sha"
+	distro = "static-binary-distro"
+	arch   = "static-binary-arch"
 )
 
 func HandleCommand() {
@@ -63,6 +66,8 @@ func handleCommand(key string, in io.Reader, out io.Writer) error {
 	case "erase":
 		return deleteAccessToken()
 	case "version":
+		return printVersion(out)
+	case "--version":
 		return printVersion(out)
 	}
 	return fmt.Errorf("Unknown credential action `%s`", key)
@@ -130,7 +135,7 @@ func getCredentials(reader io.Reader, writer io.Writer) error {
 }
 
 func printVersion(out io.Writer) error {
-	_, err := fmt.Fprintf(out, "Version: %s\nGit SHA: %s\n", Version, SHA)
+	_, err := fmt.Fprintf(out, "git-credential-netlify/%s (Netlify; %s %s; %s; git %s)\n", tag, distro, arch, runtime.Version(), sha[0:8])
 	return err
 }
 


### PR DESCRIPTION
Include Go runtime version, architecture and shorter git sha.

I like this information in one line better.
It also supports --version.

It looks like this:

```
git-credential-netlify/development (Netlify; linux amd64; go1.11.2; git 89b78ece)
```