### PR TITLE
Fix netlifyLFSPath, change Api/Lfs to API/LFS

### DIFF
--- a/credentials/auth.go
+++ b/credentials/auth.go
@@ -141,7 +141,7 @@ func tryAccessToken(host, token string) error {
 		r.SetHeaderParam("Authorization", "Bearer "+token)
 		return nil
 	}
-	client, ctx := newNetlifyApiClient(credentials)
+	client, ctx := newNetlifyAPIClient(credentials)
 	site, err := client.GetSite(ctx, host)
 	if err != nil {
 		if apiErr, ok := err.(*operations.GetSiteDefault); ok && apiErr.Payload.Code == 404 {
@@ -165,8 +165,8 @@ func tryAccessToken(host, token string) error {
 	return nil
 }
 
-func newNetlifyApiClient(credentials func(r runtime.ClientRequest, _ strfmt.Registry) error) (*porcelain.Netlify, context.Context) {
-	transport := client.New(netlifyApiHost, netlifyApiPath, apiSchemes)
+func newNetlifyAPIClient(credentials func(r runtime.ClientRequest, _ strfmt.Registry) error) (*porcelain.Netlify, context.Context) {
+	transport := client.New(netlifyAPIHost, netlifyAPIPath, apiSchemes)
 	client := porcelain.New(transport, strfmt.Default)
 
 	creds := runtime.ClientAuthInfoWriterFunc(credentials)

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -17,8 +17,8 @@ const (
 	netlifyServerName           = "https://api.netlify.com"
 	netlifyAccessTokenUser      = "access-token"
 	netlifyDefaultClientID      = "5edad8f69d47ae8923d0cf0b4ab95ba1415e67492b5af26ad97f4709160bb31b"
-	netlifyApiPath              = "/api/v1"
-	netlifyLfsPath              = "/.netlify/large-media"
+	netlifyAPIPath              = "/api/v1"
+	netlifyLFSPath              = ".netlify/large-media"
 	netlifyLargeMediaCapability = "large_media"
 
 	gitHostKey     = "host"
@@ -34,6 +34,7 @@ var (
 	arch   = "static-binary-arch"
 )
 
+// HandleCommand checks arguments and inits logger.
 func HandleCommand() {
 	initLogger()
 
@@ -101,11 +102,11 @@ func getCredentials(reader io.Reader, writer io.Writer) error {
 
 	host, exist := data[gitHostKey]
 	if !exist {
-		return fmt.Errorf("Missing host to check credentials: %s", buffer.String())
+		return fmt.Errorf("Missing host to check credentials: %v", data)
 	}
 
-	if path, exist := data[gitPathKey]; !exist || path != netlifyLfsPath {
-		return fmt.Errorf("Invalid LFS path: %s", buffer.String())
+	if path, exist := data[gitPathKey]; !exist || path != netlifyLFSPath {
+		return fmt.Errorf("Invalid LFS path: %v", data)
 	}
 
 	accessToken, err := getAccessToken(host)

--- a/credentials/login.go
+++ b/credentials/login.go
@@ -11,12 +11,12 @@ import (
 )
 
 const (
-	netlifyApiScheme = "https"
-	netlifyApiHost   = "api.netlify.com"
+	netlifyAPIScheme = "https"
+	netlifyAPIHost   = "api.netlify.com"
 	netlifyTicketURL = "https://app.netlify.com/authorize?response_type=ticket&ticket="
 )
 
-var apiSchemes = []string{netlifyApiScheme}
+var apiSchemes = []string{netlifyAPIScheme}
 
 func login(clientID, host string) (string, error) {
 	if !isTTY() {
@@ -24,7 +24,7 @@ func login(clientID, host string) (string, error) {
 		return "", nil
 	}
 
-	client, ctx := newNetlifyApiClient(noCredentials)
+	client, ctx := newNetlifyAPIClient(noCredentials)
 	ticket, err := client.CreateTicket(ctx, clientID)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
The path shouldn't start with `/`, because that's not what Git will give you.

Tested:

```
$ git credential fill
protocol=https
host=lm-cli-test.netlify.com
path=.netlify/large-media

protocol=https
host=lm-cli-test.netlify.com
path=.netlify/large-media
username=access-token
password=mygreatpassword
```

Also improved error log a bit:

```
time="2019-01-25T16:17:04-08:00" level=error msg="Aborting Netlify credential helper execution" error="Invalid LFS path: map[protocol:https host:lm-cli-test.netlify.com path:/.netlify/large-media]"
```