### PR TITLE
Fix powershell installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ brew install git-credential-netlify
 
 ```
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-iex (iwr https://github.com/netlify/netlify-credential-helper/raw/master/resources/install.ps1)
+iex (iwr -UseBasicParsing -Uri https://github.com/netlify/netlify-credential-helper/raw/master/resources/install.ps1)
 ```
 
 ### Install on Windows with Scoop


### PR DESCRIPTION
This is not always required, but the iwr command might fail in some cases without it.