### PR TITLE
Bring Netlify CLI global config file to the top of validAuthPaths

### DIFF
--- a/credentials/auth.go
+++ b/credentials/auth.go
@@ -33,9 +33,9 @@ type netlifyConfig struct {
 }
 
 var validAuthPaths = [][]string{
+	{".netlify", "config.json"},
 	{".config", "netlify"},
 	{".netlify", "config"},
-	{".netlify", "config.json"},
 	{".config", "netlify.json"},
 }
 


### PR DESCRIPTION
What title says. The current Netlify CLI's global config file should be in `$HOME/.netlify/config.json` and that should be the top when we try to search:

https://github.com/netlify/cli/blob/781686716b73d31bb4be329b42d088375f83b534/src/base/global-config/index.js

Put `.config/netlify` as a second, which is the old cli (netlifyctl)'s config file:
https://github.com/netlify/netlifyctl#obtain-a-token-in-the-netlify-ui