### PR TITLE
Fix runtime panic if not logged in

### DIFF
--- a/credentials/login.go
+++ b/credentials/login.go
@@ -1,6 +1,7 @@
 package credentials
 
 import (
+	"errors"
 	"os"
 
 	"github.com/go-openapi/runtime"
@@ -21,7 +22,7 @@ var apiSchemes = []string{netlifyAPIScheme}
 func login(clientID, host string) (string, error) {
 	if !isTTY() {
 		// do not try to login when the standard input is not a TTY.
-		return "", nil
+		return "", errors.New(`Unable to login. Not running in a TTY. Please login via "netlify login"`)
 	}
 
 	client, ctx := newNetlifyAPIClient(noCredentials)


### PR DESCRIPTION
*Fixes #39*

This changes the credential access token logic in a way that it throws an error if automatic login via cli is not possible (missing TTY). This happens when the helper is run by git.

Throwing an error at that place makes sense once the purpose of the login function is to always return valid credentials. Which it can not if there is no tty.

## Test plan

- compiled locally and copied to `~/.netlify/helper/git-credential-netlify`
- prepared `netlify-cli` without being logged in
- `git clone my-repo-with-lm`