### PR TITLE
Add netlify.app as netlifyHost

### DIFF
--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -20,7 +20,8 @@ const (
 	netlifyDefaultClientID      = "5edad8f69d47ae8923d0cf0b4ab95ba1415e67492b5af26ad97f4709160bb31b"
 	netlifyAPIPath              = "/api/v1"
 	netlifyLargeMediaCapability = "large_media_enabled"
-	netlifyHost                 = ".netlify.com"
+	netlifyHost                 = ".netlify.app"
+	netlifyAltHost              = ".netlify.com"
 
 	gitHostKey     = "host"
 	gitUsernameKey = "username"
@@ -102,8 +103,8 @@ func getCredentials(reader io.Reader, writer io.Writer) error {
 		return fmt.Errorf("Missing host to check credentials: %v", data)
 	}
 
-	if !strings.HasSuffix(host, netlifyHost) {
-		// ignore hosts that are not *.netlify.com
+	if !(strings.HasSuffix(host, netlifyHost) || strings.HasSuffix(host, netlifyAltHost)) {
+		// ignore hosts that are not *.netlify.app or *.netlify.com
 		return nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,5 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c
 	go.opencensus.io v0.18.0 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
Netlify recently migrated the default site domain from netlify.com to netlify.app.
This change will support using this helper with netlify.app too.