### PR TITLE
fix: load token from shared config dir

### DIFF
--- a/credentials/auth.go
+++ b/credentials/auth.go
@@ -71,7 +71,15 @@ func saveAccessToken(token string) error {
 		return err
 	}
 
-	f, err := os.OpenFile(filepath.Join(validAuthPaths[0]...), os.O_CREATE|os.O_RDWR, 0644)
+	configPath := filepath.Join(validAuthPaths[0]...)
+
+	// make sure the directory structure exists
+	err = os.MkdirAll(filepath.Dir(configPath), 0644)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(configPath, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		return err
 	}

--- a/credentials/auth.go
+++ b/credentials/auth.go
@@ -74,12 +74,12 @@ func saveAccessToken(token string) error {
 	configPath := filepath.Join(validAuthPaths[0]...)
 
 	// make sure the directory structure exists
-	err = os.MkdirAll(filepath.Dir(configPath), 0644)
+	err = os.MkdirAll(filepath.Dir(configPath), 0700)
 	if err != nil {
 		return err
 	}
 
-	f, err := os.OpenFile(configPath, os.O_CREATE|os.O_RDWR, 0644)
+	f, err := os.OpenFile(configPath, os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		return err
 	}

--- a/credentials/auth_test.go
+++ b/credentials/auth_test.go
@@ -80,10 +80,10 @@ func testLoadAccessTokenFromConfigDir(t *testing.T) {
 	input, err := ioutil.ReadFile(filepath.Join("_testdata", "netlify-node-cli.json"))
 	check(t, err)
 
-	err = os.MkdirAll(configPath, os.ModePerm)
+	err = os.MkdirAll(configPath, 0700)
 	check(t, err)
 
-	err = ioutil.WriteFile(filepath.Join(configPath, "config.json"), input, 0644)
+	err = ioutil.WriteFile(filepath.Join(configPath, "config.json"), input, 0600)
 	check(t, err)
 
 	token, err := loadAccessTokenFromAuthPaths("foobar.com", checkFakeHostAccess)

--- a/credentials/auth_test.go
+++ b/credentials/auth_test.go
@@ -2,8 +2,13 @@ package credentials
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
+
+	homedir "github.com/mitchellh/go-homedir"
 )
 
 func TestLoadAccessToken(t *testing.T) {
@@ -11,6 +16,7 @@ func TestLoadAccessToken(t *testing.T) {
 	t.Run("with the old config format", testLoadAccessTokenFromOldCli)
 	t.Run("with the node multi user config format", testLoadAccessTokenFromMultiUser)
 	t.Run("with the node invalid config", testLoadAccessTokenFromInvalidUser)
+	t.Run("with shared config dir", testLoadAccessTokenFromConfigDir)
 }
 
 func testLoadAccessTokenFromNewCli(t *testing.T) {
@@ -27,9 +33,7 @@ func testLoadAccessTokenFromMultiUser(t *testing.T) {
 
 func testLoadAccessTokenFromInvalidUser(t *testing.T) {
 	f, err := os.Open("_testdata/netlify-invalid-creds.json")
-	if err != nil {
-		t.Fatal(err)
-	}
+	check(t, err)
 	defer f.Close()
 
 	token, err := loadAccessTokenFromFile(f, "foobar.com", checkFakeHostAccess)
@@ -48,15 +52,42 @@ func testLoadAccessTokenFromInvalidUser(t *testing.T) {
 
 func testLoadAccessTokenFromCli(t *testing.T, path string) {
 	f, err := os.Open(path)
-	if err != nil {
-		t.Fatal(err)
-	}
+	check(t, err)
 	defer f.Close()
 
 	token, err := loadAccessTokenFromFile(f, "foobar.com", checkFakeHostAccess)
-	if err != nil {
-		t.Fatal(err)
+	check(t, err)
+	if token != "verysecret" {
+		t.Errorf("expected `verysecret`, got `%s`", token)
 	}
+}
+
+func testLoadAccessTokenFromConfigDir(t *testing.T) {
+	home, err := homedir.Dir()
+	check(t, err)
+
+	var configPath string
+	switch runtime.GOOS {
+	case "windows":
+		configPath = filepath.Join(home, "AppData", "Roaming", "netlify", "Config")
+	case "darwin":
+		configPath = filepath.Join(home, "Library", "Preferences", "netlify")
+	default:
+		configPath = filepath.Join(home, ".config", "netlify")
+	}
+
+	// copy test token to shared config path
+	input, err := ioutil.ReadFile(filepath.Join("_testdata", "netlify-node-cli.json"))
+	check(t, err)
+
+	err = os.MkdirAll(configPath, os.ModePerm)
+	check(t, err)
+
+	err = ioutil.WriteFile(filepath.Join(configPath, "config.json"), input, 0644)
+	check(t, err)
+
+	token, err := loadAccessTokenFromAuthPaths("foobar.com", checkFakeHostAccess)
+	check(t, err)
 	if token != "verysecret" {
 		t.Errorf("expected `verysecret`, got `%s`", token)
 	}
@@ -67,4 +98,10 @@ func checkFakeHostAccess(host, token string) error {
 		return nil
 	}
 	return fmt.Errorf("unauthorized")
+}
+
+func check(t *testing.T, err error) {
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/netlify/netlify-credential-helper
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.3.0 // indirect
 	github.com/Azure/go-autorest v11.2.8+incompatible // indirect
+	github.com/adrg/xdg v0.3.0
 	github.com/cenkalti/backoff v2.1.0+incompatible // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/go-openapi/runtime v0.17.2

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/PuerkitoBio/purell v1.1.0 h1:rmGxhojJlM0tuKtfdvliR84CFHljx9ag64t2xmVk
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/adrg/xdg v0.3.0 h1:BO+k4wFj0IoTolBF1Apn8oZrX3LQrEbBA8+/9vyW9J4=
+github.com/adrg/xdg v0.3.0/go.mod h1:7I2hH/IT30IsupOpKZ5ue7/qNi3CoKzD6tL3HwpaRMQ=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf h1:eg0MeVzsP1G42dRafH3vf+al2vQIJU0YHX+1Tw87oco=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -16,6 +18,7 @@ github.com/cenkalti/backoff v2.1.0+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/census-instrumentation/opencensus-proto v0.0.2-0.20180913191712-f303ae3f8d6a h1:t88pXOTS5K+pjfuhTOcul6sdC4khgqB8ukyfbe62Zxo=
 github.com/census-instrumentation/opencensus-proto v0.0.2-0.20180913191712-f303ae3f8d6a/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
@@ -87,9 +90,12 @@ github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c h1:fyKiXKO1/I/B6Y2U8T7WdQGWzwehOuGIrljPtt7YTTI=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.opencensus.io v0.17.0/go.mod h1:mp1VrMQxhlqqDpKvH4UcQUa4YwlzNmymAjPrDdfxNpI=
 go.opencensus.io v0.18.0 h1:Mk5rgZcggtbvtAun5aJzAtjKKN/t0R3jJPlWILlv938=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
@@ -123,4 +129,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Please forgive my lack of `go` knowledge.

~~This is pending https://github.com/netlify/netlify-credential-helper/pull/50 so I can test this on Windows.~~

Kind of required for https://github.com/netlify/cli/pull/1489.

In https://github.com/netlify/cli/pull/1725 we changed the location of `config.json` without realizing it is referenced in this client and in https://github.com/netlify/netlify-lm-plugin.

https://github.com/netlify/cli/pull/1489 handles the plugin part, this PR is intended to handle the `go` client part.