### PR TITLE
Codeowners update

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @netlify/workflow
+* @netlify/dev-workflow-pod-americas @netlify/dev-workflow-pod-emea

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @netlify/dev-workflow-pod-americas @netlify/dev-workflow-pod-emea
+* @netlify/ecosystem-pod-composable-tooling


### PR DESCRIPTION

This PR is an honest attempt to set the correct team(s) as a [codeowner](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners) for this repo. If the team listed is incorrect but you know who should have it, feel free to make a change.

Otherwise, if it looks good, just smash that merge button. (please and thank you)

If you need any help finding a home for this repo, reach out to the FSRE team in #crew-forward-sre and we can help shepherd this along. 